### PR TITLE
Add LWZUX instruction

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -1236,6 +1236,12 @@ bool Recompiler::Recompile(
         println("{}.u32);", r(insn.operands[2]));
         break;
 
+    case PPC_INST_LWZUX:
+        println("\t{} = {}.u32 + {}.u32;", ea(), r(insn.operands[1]), r(insn.operands[2]));
+        println("\t{}.u64 = PPC_LOAD_U32({});", r(insn.operands[0]), ea());
+        println("\t{}.u32 = {};", r(insn.operands[1]), ea());
+        break;
+
     case PPC_INST_MFCR:
         for (size_t i = 0; i < 32; i++)
         {


### PR DESCRIPTION
I’m trying to recompile the Joy Ride Turbo game. This game uses **LWZUX** instructions. The code is working. At least there are no bugs due to LWZUX.

Before:
<img width="433" height="72" alt="xen1" src="https://github.com/user-attachments/assets/1441f9eb-26c3-4cf0-909f-0b5ca8bb13ef" />
After:
<img width="396" height="88" alt="xen2" src="https://github.com/user-attachments/assets/3528afbb-6183-4f3b-8066-6b774f0516f9" />
